### PR TITLE
Handle undefined correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@
   var TRUTHY_VALUES = 'y yes true'.split(/\s/);
 
   function toBoolean(value) {
+    if(value === undefined) {
+        return false;    	
+    }
+
     value = value.toString();
     value = value.trim();
     value = value.toLowerCase();

--- a/test.js
+++ b/test.js
@@ -18,5 +18,6 @@ test('falsy', function(t) {
   t.deepEqual(toBoolean(''), false, 'empty string is "false"');
   t.deepEqual(toBoolean('        '), false, 'giant empty string is "false"');
   t.deepEqual(toBoolean('0'), false, '"0" is "false"');
+  t.deepEqual(toBoolean(undefined), false, 'undefined is false');
   t.end();
 });


### PR DESCRIPTION
Hi!

I suppose that `undefined` must be treated as falsy value. For now, exception is thrown when `undefined` is passed.